### PR TITLE
Only send player state when changed event is emitted by game.controls

### DIFF
--- a/client.js
+++ b/client.js
@@ -54,8 +54,7 @@ function connectToGameServer(socket) {
 function createGame(options) {
   options.controlsDisabled = false
   window.game = engine(options)
-
-  setInterval(function() {
+  game.controls.on('changed', function() {
     if (!connected) return
     if (!game.controls.enabled) return
     var state = {
@@ -66,7 +65,7 @@ function createGame(options) {
       }
     }
     emitter.emit('state', state)
-  }, 1000/22)
+  });
 
   var container = document.querySelector('#container')
   game.appendTo(container)


### PR DESCRIPTION
NOTE: requires update to player-physics module to emit this event
Corresponding pull request is here: https://github.com/maxogden/player-physics/pull/7

Addresses issue: TODO: Have client only send player's position/rotation on change https://github.com/maxogden/voxel-server/issues/9
