### PR TITLE
Upgrade voxel-crunch to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "toolbar": "0.0.5",
     "voxel-player": "0.0.2",
     "voxel-engine": "~0.16.0",
-    "voxel-crunch": "0.1.1",
+    "voxel-crunch": "0.2.1",
     "websocket-stream": "0.0.5",
     "ws": "0.4.25",
     "ecstatic": "0.3.0",


### PR DESCRIPTION
@maxogden - Max - I am making a pull request against voxel-client to upgrade the crunch version.

I'm making the same change here in client to match the version, though no other change is needed.
